### PR TITLE
Core Design: update core-icon loading to npm package

### DIFF
--- a/src/components/core-icon/utils.ts
+++ b/src/components/core-icon/utils.ts
@@ -52,7 +52,9 @@ const getNamedUrl = (iconName: string) => {
   if (url) {
     return url;
   }
-  return getAssetPath(`assets/core-icons/16/${iconName}.svg`);
+  return getAssetPath(
+    `https://unpkg.com/@core-ds/icons/icons/16/${iconName}.svg`
+  );
 };
 
 export const getName = (

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -16,12 +16,6 @@ export const config: Config = {
     {
       type: "www",
       serviceWorker: null,
-      copy: [
-        {
-          src: "../node_modules/@core-ds/icons/icons",
-          dest: "build/assets/core-icons",
-        },
-      ],
     },
   ],
   plugins: [


### PR DESCRIPTION
Update core-icons to load via `@core-ds/icons` which fixes `@core-design/components` icons