### PR TITLE
add core-progress component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -218,6 +218,24 @@ export namespace Components {
          */
         "type"?: string;
     }
+    interface CoreProgress {
+        /**
+          * Color of the progress bar. Use: `color="black"`, `color="red"`, etc. Default color is `"blue"`.
+         */
+        "color"?: "black" | "blue" | "green" | "yellow" | "red";
+        /**
+          * The progress bar maximum value.
+         */
+        "max": number;
+        /**
+          * The pre-defined progress bar size. Use: `"small"` or `"large"`. Default size is `"large"`.
+         */
+        "size"?: "small" | "large";
+        /**
+          * The progress bar value.
+         */
+        "value": number | undefined;
+    }
     interface CoreRadio {
         /**
           * If applied, the element is checked. Use: `"checked"`.
@@ -342,6 +360,12 @@ declare global {
         prototype: HTMLCoreInputElement;
         new (): HTMLCoreInputElement;
     };
+    interface HTMLCoreProgressElement extends Components.CoreProgress, HTMLStencilElement {
+    }
+    var HTMLCoreProgressElement: {
+        prototype: HTMLCoreProgressElement;
+        new (): HTMLCoreProgressElement;
+    };
     interface HTMLCoreRadioElement extends Components.CoreRadio, HTMLStencilElement {
     }
     var HTMLCoreRadioElement: {
@@ -369,6 +393,7 @@ declare global {
         "core-field-label": HTMLCoreFieldLabelElement;
         "core-icon": HTMLCoreIconElement;
         "core-input": HTMLCoreInputElement;
+        "core-progress": HTMLCoreProgressElement;
         "core-radio": HTMLCoreRadioElement;
         "core-textarea": HTMLCoreTextareaElement;
         "core-toggle": HTMLCoreToggleElement;
@@ -583,6 +608,24 @@ declare namespace LocalJSX {
          */
         "type"?: string;
     }
+    interface CoreProgress {
+        /**
+          * Color of the progress bar. Use: `color="black"`, `color="red"`, etc. Default color is `"blue"`.
+         */
+        "color"?: "black" | "blue" | "green" | "yellow" | "red";
+        /**
+          * The progress bar maximum value.
+         */
+        "max"?: number;
+        /**
+          * The pre-defined progress bar size. Use: `"small"` or `"large"`. Default size is `"large"`.
+         */
+        "size"?: "small" | "large";
+        /**
+          * The progress bar value.
+         */
+        "value"?: number | undefined;
+    }
     interface CoreRadio {
         /**
           * If applied, the element is checked. Use: `"checked"`.
@@ -662,6 +705,7 @@ declare namespace LocalJSX {
         "core-field-label": CoreFieldLabel;
         "core-icon": CoreIcon;
         "core-input": CoreInput;
+        "core-progress": CoreProgress;
         "core-radio": CoreRadio;
         "core-textarea": CoreTextarea;
         "core-toggle": CoreToggle;
@@ -679,6 +723,7 @@ declare module "@stencil/core" {
             "core-field-label": LocalJSX.CoreFieldLabel & JSXBase.HTMLAttributes<HTMLCoreFieldLabelElement>;
             "core-icon": LocalJSX.CoreIcon & JSXBase.HTMLAttributes<HTMLCoreIconElement>;
             "core-input": LocalJSX.CoreInput & JSXBase.HTMLAttributes<HTMLCoreInputElement>;
+            "core-progress": LocalJSX.CoreProgress & JSXBase.HTMLAttributes<HTMLCoreProgressElement>;
             "core-radio": LocalJSX.CoreRadio & JSXBase.HTMLAttributes<HTMLCoreRadioElement>;
             "core-textarea": LocalJSX.CoreTextarea & JSXBase.HTMLAttributes<HTMLCoreTextareaElement>;
             "core-toggle": LocalJSX.CoreToggle & JSXBase.HTMLAttributes<HTMLCoreToggleElement>;

--- a/src/components/core-progress/core-progress.less
+++ b/src/components/core-progress/core-progress.less
@@ -1,0 +1,77 @@
+@import (reference) "https://unpkg.com/@core-ds/primitives/core-primitives.less";
+
+// :host targets the custom element compiled by Stencil
+:host {
+  display: flex;
+
+  // @Prop color
+  &(.black) progress::-webkit-progress-value {
+    background-color: @color-black;
+  }
+  &(.black) progress::-moz-progress-bar {
+    background-color: @color-black;
+  }
+
+  &(.blue) progress::-webkit-progress-value {
+    background-color: @color-blue;
+  }
+  &(.blue) progress::-moz-progress-bar {
+    background-color: @color-blue;
+  }
+
+  &(.green) progress::-webkit-progress-value {
+    background-color: @color-green;
+  }
+  &(.green) progress::-moz-progress-bar {
+    background-color: @color-green;
+  }
+
+  &(.yellow) progress::-webkit-progress-value {
+    background-color: @color-yellow;
+  }
+  &(.yellow) progress::-moz-progress-bar {
+    background-color: @color-yellow;
+  }
+
+  &(.red) progress::-webkit-progress-value {
+    background-color: @color-red;
+  }
+  &(.red) progress::-moz-progress-bar {
+    background-color: @color-red;
+  }
+
+  // @Prop small size
+  &([size="small"]) progress,
+  &([size="small"]) progress::-webkit-progress-bar {
+    border-radius: @border-radius-sm;
+    height: @space-1;
+  }
+}
+
+// native element styles with intentional lower specificity
+progress {
+  appearance: none;
+  border: none;
+  border-radius: @border-radius-md;
+  box-sizing: border-box;
+  color: @color-blue; // progress bar color for IE
+  cursor: default;
+  height: @space-2;
+  min-width: 100px;
+  overflow: hidden;
+  width: inherit;
+
+  &::-moz-progress-bar {
+    background-color: @color-blue;
+    border-radius: @border-radius-md;
+  }
+}
+
+progress::-webkit-progress-bar {
+  background-color: @color-gray-2;
+}
+
+progress::-webkit-progress-value {
+  background-color: @color-blue;
+  border-radius: @border-radius-md;
+}

--- a/src/components/core-progress/core-progress.tsx
+++ b/src/components/core-progress/core-progress.tsx
@@ -1,0 +1,56 @@
+import {
+  Component,
+  ComponentInterface,
+  Element,
+  Host,
+  Prop,
+  h,
+} from "@stencil/core";
+
+@Component({
+  tag: "core-progress",
+  styleUrl: "core-progress.less",
+  shadow: true,
+})
+export class Progress implements ComponentInterface {
+  @Element() el!: HTMLElement;
+
+  /**
+   * Color of the progress bar.
+   * Use: `color="black"`, `color="red"`, etc.
+   * Default color is `"blue"`.
+   */
+  @Prop() color?: "black" | "blue" | "green" | "yellow" | "red" = "blue";
+
+  /**
+   * The progress bar maximum value.
+   */
+  @Prop() max = 100;
+
+  /**
+   * The pre-defined progress bar size.
+   * Use: `"small"` or `"large"`.
+   * Default size is `"large"`.
+   */
+  @Prop() size?: "small" | "large" = "large";
+
+  /**
+   * The progress bar value.
+   */
+  @Prop() value: number | undefined;
+
+  render() {
+    const { color } = this;
+
+    return (
+      <Host
+        class={{
+          "core-progress": true,
+          [`${color}`]: color !== undefined,
+        }}
+      >
+        <progress max={this.max} value={this.value}></progress>
+      </Host>
+    );
+  }
+}

--- a/src/components/core-progress/readme.md
+++ b/src/components/core-progress/readme.md
@@ -1,0 +1,18 @@
+# core-progress
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description                                                                                     | Type                                                | Default     |
+| -------- | --------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `color`  | `color`   | Color of the progress bar. Use: `color="black"`, `color="red"`, etc. Default color is `"blue"`. | `"black" \| "blue" \| "green" \| "red" \| "yellow"` | `"blue"`    |
+| `max`    | `max`     | The progress bar maximum value.                                                                 | `number`                                            | `100`       |
+| `size`   | `size`    | The pre-defined progress bar size. Use: `"small"` or `"large"`. Default size is `"large"`.      | `"large" \| "small"`                                | `"large"`   |
+| `value`  | `value`   | The progress bar value.                                                                         | `number`                                            | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/index.html
+++ b/src/index.html
@@ -77,6 +77,12 @@
       .badges.grid {
         grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
       }
+      .progress.grid {
+        grid-template-columns: repeat(auto-fill, minmax(227px, 1fr));
+      }
+      .progress.grid core-progress {
+        width: 100%;
+      }
     </style>
   </head>
   <body>
@@ -604,6 +610,32 @@
           <core-badge size="small" variation="bordered">8</core-badge>
           <core-badge size="small">345</core-badge>
           <core-badge size="small" variation="bordered">345</core-badge>
+        </div>
+      </div>
+    </section>
+    <section id="progress">
+      <h2>Progress</h2>
+      <div class="grid">
+        <div class="progress grid">
+          <core-progress value="60"></core-progress>
+        </div>
+        <div class="progress grid">
+          <core-progress value="33" size="small"></core-progress>
+        </div>
+        <div class="progress grid">
+          <core-progress value="100" color="green" size="small"></core-progress>
+        </div>
+        <div class="progress grid">
+          <core-progress value="75" color="yellow" size="small"></core-progress>
+        </div>
+        <div class="progress grid">
+          <core-progress value="50" color="red" size="small"></core-progress>
+        </div>
+        <div class="progress grid">
+          <core-progress value="25" color="black" size="small"></core-progress>
+        </div>
+        <div class="progress grid">
+          <core-progress value="0" color="black" size="small"></core-progress>
         </div>
       </div>
     </section>


### PR DESCRIPTION
- adds core-progress component made up of a native <progress> element
    - styling was tricky, be careful when modifying

```html
<core-progress value="75" color="yellow" size="small"></core-progress>
```