### PR TITLE
move stencil-build --docs flag

### DIFF
--- a/packages/components/custom-elements.json
+++ b/packages/components/custom-elements.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2020-06-16T17:35:01",
+  "timestamp": "2020-06-23T19:52:25",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.13.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,8 +23,9 @@
   },
   "scripts": {
     "build": "npm-run-all clean build-stencil",
-    "build-netlify": "npm-run-all build-stencil build-storybook",
-    "build-stencil": "stencil build --docs --no-cache",
+    "build-netlify": "npm-run-all build-stencil-docs build-storybook",
+    "build-stencil": "stencil build --no-cache",
+    "build-stencil-docs": "stencil build --docs --no-cache",
     "build-storybook": "build-storybook --static-dir dist --output-dir storybook/ --quiet",
     "clean": "rm -rf dist",
     "generate": "stencil generate",


### PR DESCRIPTION
This pull moves the `--docs` flag from `build-stencil` into `build-stencil-docs` to isolate from package deployment

cr_req 1
qa_req 0