### PR TITLE
core-design: Remove obsolete scripts

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,12 +22,10 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm-run-all clean build-stencil",
     "build-netlify": "npm-run-all build-stencil-docs build-storybook",
     "build-stencil": "stencil build --no-cache",
     "build-stencil-docs": "stencil build --docs --no-cache",
     "build-storybook": "build-storybook --static-dir dist --output-dir storybook/ --quiet",
-    "clean": "rm -rf dist",
     "generate": "stencil generate",
     "lint": "eslint src/**/*{.ts,.tsx}",
     "start": "stencil build --dev --watch --serve",

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ npm login
 Before publishing to NPM we need to build all the packages:
 
 ```bash
-lerna run build
+lerna run build-stencil
 ```
 
 Then, publish to NPM:


### PR DESCRIPTION
This pull removes a few obsolete scripts from `package.json` and adjusts the root readme to reflect preferred versions

qa_req 0