### PR TITLE
Inline Informer SVGs, add `pill` mixin, remove label containers

### DIFF
--- a/packages/components-web/src/assets/style/global.less
+++ b/packages/components-web/src/assets/style/global.less
@@ -14,10 +14,14 @@
 // 3. Variables
 @focus-box-shadow: 0 0 0 3px fade(@color-blue-light-1, 30%);
 @space-large: 20px;
-@tab-line-height: 3px;
-@text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.15);
 
-// 4. Shared styles - `:host` targets the custom element compiled by Stencil
+// 4. Mixins
+.pill(@height) {
+  border-radius: calc(@height~"/ 2");
+  height: @height;
+}
+
+// 5. Styles - `:host` targets the custom element compiled by Stencil
 :host {
   font-family: "Inter Var", -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif;
   font-feature-settings: "calt" on, "cpsp" on, "cv01" on, "cv03" on, "cv04" on, "cv05" on, "cv10" on, "kern" on, "liga" on;

--- a/packages/components-web/src/assets/style/style-guide.less
+++ b/packages/components-web/src/assets/style/style-guide.less
@@ -77,10 +77,10 @@ main {
 
 h2 {
   background: @color-white;
-  background: linear-gradient(180deg, rgba(255,255,255,1) 90%, rgba(255,255,255,0.75) 97%, rgba(255,255,255,0) 100%);
-  margin: 0 -@space-5 @space-8;
+  background: linear-gradient(180deg, rgba(255,255,255,1) 80%, rgba(255,255,255,0.75) 90%, rgba(255,255,255,0) 100%);
+  margin: 0 -@space-5;
   overflow-x: hidden;
-  padding: @space-3 0 @space-1;
+  padding: @space-2 0;
   position: sticky;
   top: -1px;
   z-index: 2;

--- a/packages/components-web/src/components.d.ts
+++ b/packages/components-web/src/components.d.ts
@@ -369,6 +369,10 @@ export namespace Components {
          */
         "labelPosition"?: labelPositionProps;
         /**
+          * The radio group name that links other radio elements. [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#Defining_a_radio_group)
+         */
+        "name": string | undefined;
+        /**
           * If applied, the user must fill in a value before submitting a form containing this element.
          */
         "required": boolean;
@@ -1042,6 +1046,10 @@ declare namespace LocalJSX {
           * The label element position.
          */
         "labelPosition"?: labelPositionProps;
+        /**
+          * The radio group name that links other radio elements. [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#Defining_a_radio_group)
+         */
+        "name"?: string | undefined;
         /**
           * If applied, the user must fill in a value before submitting a form containing this element.
          */

--- a/packages/components-web/src/components/core-badge/core-badge.less
+++ b/packages/components-web/src/components/core-badge/core-badge.less
@@ -48,9 +48,8 @@
 
   // @Prop small size
   &([size="small"]) .native-element {
-    border-radius: calc(@space-4 / 2);
+    .pill(@space-4);
     font-size: 11px;
-    height: @space-4;
     letter-spacing: unset;
     line-height: @space-3;
     min-width: @space-4;
@@ -70,15 +69,14 @@
 
 // native element styles with intentional lower specificity
 .native-element {
+  .pill(@badge-space-lg);
   align-items: center;
-  border-radius: calc(@badge-space-lg / 2);
   box-sizing: border-box;
   cursor: default;
   display: flex;
   font: inherit;
   font-size: 12px;
   font-weight: bold;
-  height: @badge-space-lg;
   justify-content: center;
   line-height: 15px;
   max-width: 100%;

--- a/packages/components-web/src/components/core-checkbox/core-checkbox.less
+++ b/packages/components-web/src/components/core-checkbox/core-checkbox.less
@@ -43,13 +43,13 @@
 
   // @Prop labelPositionProps
   &([label]:not([label-position="left"])) {
-    .label-outer {
+    label {
       margin-left: @space-2;
     }
   }
 
   &([label-position="left"]) {
-    .label-outer {
+    label {
       margin-right: @space-2;
       order: -1;
     }

--- a/packages/components-web/src/components/core-checkbox/core-checkbox.tsx
+++ b/packages/components-web/src/components/core-checkbox/core-checkbox.tsx
@@ -80,11 +80,7 @@ export class Checkbox implements ComponentInterface {
             disabled={this.disabled}
             required={this.required}
           />
-          {this.label && (
-            <div class="label-outer">
-              <label htmlFor={this.label}>{this.label}</label>
-            </div>
-          )}
+          {this.label && <label htmlFor={this.label}>{this.label}</label>}
         </div>
       </Host>
     );

--- a/packages/components-web/src/components/core-input/core-input.less
+++ b/packages/components-web/src/components/core-input/core-input.less
@@ -31,7 +31,7 @@
       justify-content: center;
     }
 
-    .label-outer {
+    label {
       align-self: center;
       display: flex;
       margin-bottom: 0;
@@ -39,7 +39,7 @@
   }
 
   // @Prop labelPositionProps
-  &([label-position="left"]) .label-outer {
+  &([label-position="left"]) label {
     margin-right: @space-2;
   }
 
@@ -49,13 +49,13 @@
       flex-direction: row-reverse;
     }
 
-    .label-outer {
+    label {
       margin-left: @space-2;
     }
   }
 
   &([label-display="block"][label-position="right"]) {
-    .label-outer {
+    label {
       justify-content: flex-end;
     }
   }
@@ -103,7 +103,7 @@
   }
 }
 
-.label-outer {
+label {
   display: flex;
   margin-bottom: @space-2;
 }

--- a/packages/components-web/src/components/core-input/core-input.tsx
+++ b/packages/components-web/src/components/core-input/core-input.tsx
@@ -119,11 +119,7 @@ export class Input implements ComponentInterface {
         }}
       >
         <div class="input-outer">
-          {this.label && (
-            <div class="label-outer">
-              <label htmlFor={this.label}>{this.label}</label>
-            </div>
-          )}
+          {this.label && <label htmlFor={this.label}>{this.label}</label>}
           <div class="input-inner">
             <slot name="input-left">
               {this.icon && (

--- a/packages/components-web/src/components/core-radio/core-radio.less
+++ b/packages/components-web/src/components/core-radio/core-radio.less
@@ -31,24 +31,24 @@
       width: @space-large;
 
       &:checked:not(:disabled) {
-        box-shadow: 0 0 0 5px @color-blue inset;
+        box-shadow: 0 0 0 6px @color-blue inset;
       }
 
       &:checked:disabled {
-        box-shadow: 0 0 0 5px @color-blue-light-3 inset;
+        box-shadow: 0 0 0 6px @color-blue-light-3 inset;
       }
     }
   }
 
   // @Prop labelPositionProps
   &([label-position="right"]) {
-    .label-outer {
+    label {
       margin-left: @space-2;
     }
   }
 
   &([label-position="left"]) {
-    .label-outer {
+    label {
       margin-right: @space-2;
       order: -1;
     }
@@ -73,9 +73,9 @@ label {
 
 .native-element {
   background-color: @color-white;
-  border: 1px solid @color-gray-3;
+  border: 0;
   border-radius: 50%;
-  box-shadow: 0 0 0 0 transparent inset;
+  box-shadow: 0 0 0 1px @color-gray-3 inset;
   box-sizing: border-box;
   cursor: pointer;
   display: flex;
@@ -89,7 +89,7 @@ label {
   &:checked:not(:disabled) {
     &:focus,
     &:active {
-      box-shadow: 0 0 0 4px @color-blue inset;
+      box-shadow: 0 0 0 5px @color-blue inset;
     }
   }
 
@@ -102,7 +102,7 @@ label {
 
   &[disabled]:checked {
     border-color: @color-blue-light-3;
-    box-shadow: 0 0 0 4px @color-blue-light-3 inset;
+    box-shadow: 0 0 0 5px @color-blue-light-3 inset;
   }
 }
 
@@ -113,7 +113,7 @@ label {
 
     &:checked {
       border-color: @color-blue-dark-1;
-      box-shadow: 0 0 0 4px @color-blue inset;
+      box-shadow: 0 0 0 5px @color-blue inset;
     }
   }
 }

--- a/packages/components-web/src/components/core-radio/core-radio.tsx
+++ b/packages/components-web/src/components/core-radio/core-radio.tsx
@@ -37,9 +37,14 @@ export class Radio implements ComponentInterface {
   @Prop({ reflect: true }) labelPosition?: labelPositionProps = "right";
 
   /**
+   * The radio group name that links other radio elements. [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#Defining_a_radio_group)
+   */
+  @Prop({ reflect: true }) name: string | undefined;
+
+  /**
    * If applied, the user must fill in a value before submitting a form containing this element.
    */
-  @Prop({ reflect: true }) required = false;
+  @Prop() required = false;
 
   /**
    * Apply the pre-defined large element size styling.
@@ -69,13 +74,10 @@ export class Radio implements ComponentInterface {
             type="radio"
             checked={this.checked}
             disabled={this.disabled}
+            name={this.name}
             required={this.required}
           />
-          {this.label && (
-            <div class="label-outer">
-              <label htmlFor={this.label}>{this.label}</label>
-            </div>
-          )}
+          {this.label && <label htmlFor={this.label}>{this.label}</label>}
         </div>
       </Host>
     );

--- a/packages/components-web/src/components/core-tab-group/core-tab-group.less
+++ b/packages/components-web/src/components/core-tab-group/core-tab-group.less
@@ -1,3 +1,5 @@
+@tab-line-height: 3px;
+
 // `:host` targets the custom element compiled by Stencil
 :host {
   display: flex;
@@ -6,8 +8,7 @@
   &::after {
     content: "";
     background-color: @color-gray-2;
-    border-radius: calc(@tab-line-height / 2);
-    height: @tab-line-height;
+    .pill(@tab-line-height);
     position: absolute;
     bottom: 0;
     width: 100%;
@@ -22,8 +23,7 @@
     line-height: 1.142857;
 
     &::after {
-      border-radius: calc(2px / 2);
-      height: 2px;
+      .pill(2px);
     }
 
     .native-element {

--- a/packages/components-web/src/components/core-tab/core-tab.less
+++ b/packages/components-web/src/components/core-tab/core-tab.less
@@ -1,3 +1,5 @@
+@tab-line-height: 3px;
+
 // `shadow: false' is set in `core-tab.tsx`, so we target the custom-element selector directly instead of `:host` and remove the LESS selector wrapping parenthesis for targeting in shadow-dom
 core-tab {
   display: flex;
@@ -11,10 +13,9 @@ core-tab {
   &[active],
   .native-element:hover {
     &::after {
+      .pill(@tab-line-height);
       content: "";
       background-color: transparent;
-      border-radius: calc(@tab-line-height / 2);
-      height: @tab-line-height;
       position: absolute;
       left: 0;
       bottom: 0;

--- a/packages/components-web/src/components/core-tag/core-tag.less
+++ b/packages/components-web/src/components/core-tag/core-tag.less
@@ -1,3 +1,5 @@
+@text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.15);
+
 // `:host` targets the custom element compiled by Stencil
 :host {
   display: inline-flex;
@@ -11,7 +13,7 @@
       padding-right: 3px;
     }
 
-    .closable {
+    .close {
       color: fade(@color-white, 50%);
       display: block;
     }
@@ -19,14 +21,14 @@
 
   &([closable]:not([closable="false"])[variation="light"]),
   &([closable="true"][variation="light"]) {
-    .closable {
+    .close {
       color: fade(@color-black, 15%);
     }
   }
 
   &([closable]:not([closable="false"])[color="yellow"]),
   &([closable="true"][color="yellow"]) {
-    .closable {
+    .close {
       color: fade(@color-gray-8, 25%);
     }
   }
@@ -96,13 +98,9 @@
     line-height: 14px;
     padding: 2px @space-1;
 
-    .closable {
+    .close {
       margin-top: -1px;
     }
-  }
-
-  core-icon {
-    cursor: pointer;
   }
 }
 

--- a/packages/components-web/src/components/core-tag/core-tag.tsx
+++ b/packages/components-web/src/components/core-tag/core-tag.tsx
@@ -46,8 +46,20 @@ export class Tag implements ComponentInterface {
           <slot></slot>
           <slot name="tag-right"></slot>
           {this.closable && (
-            <div class="closable">
-              <core-icon icon="cross-sm"></core-icon>
+            <div class="close">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="currentColor"
+                class="cross-sm"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M9.41 8l2.29-2.29c.19-.18.3-.43.3-.71a1.003 1.003 0 0 0-1.71-.71L8 6.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42L6.59 8 4.3 10.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71L8 9.41l2.29 2.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71L9.41 8z"
+                />
+              </svg>
             </div>
           )}
         </div>

--- a/packages/components-web/src/components/core-textarea/core-textarea.less
+++ b/packages/components-web/src/components/core-textarea/core-textarea.less
@@ -18,7 +18,7 @@
       display: block;
     }
 
-    .label-outer {
+    label {
       margin-bottom: @space-2;
     }
   }
@@ -29,7 +29,7 @@
       justify-content: center;
     }
 
-    .label-outer {
+    label {
       align-self: center;
       display: flex;
       margin-bottom: 0;
@@ -37,7 +37,7 @@
   }
 
   // @Prop labelPositionProps
-  &([label-position="left"]) .label-outer {
+  &([label-position="left"]) label {
     margin-right: @space-2;
   }
 
@@ -47,19 +47,19 @@
       flex-direction: row-reverse;
     }
 
-    .label-outer {
+    label {
       margin-left: @space-2;
     }
   }
 
   &([label-display="block"][label-position="right"]) {
-    .label-outer {
+    label {
       justify-content: flex-end;
     }
   }
 }
 
-.label-outer {
+label {
   display: flex;
 }
 

--- a/packages/components-web/src/components/core-textarea/core-textarea.tsx
+++ b/packages/components-web/src/components/core-textarea/core-textarea.tsx
@@ -88,11 +88,7 @@ export class Textarea implements ComponentInterface {
         aria-disabled={this.disabled ? "true" : null}
       >
         <div class="textarea-outer">
-          {this.label && (
-            <div class="label-outer">
-              <label htmlFor={this.label}>{this.label}</label>
-            </div>
-          )}
+          {this.label && <label htmlFor={this.label}>{this.label}</label>}
           <textarea
             class="native-element"
             ref={(el) => (this.nativeInput = el)}

--- a/packages/components-web/src/components/core-toast/core-toast.less
+++ b/packages/components-web/src/components/core-toast/core-toast.less
@@ -43,6 +43,7 @@
 
   .toast-triggers {
     display: flex;
+    align-items: center;
     justify-content: space-between;
 
     & > div:not(:last-child)::after {
@@ -59,14 +60,11 @@
     .undo,
     .close {
       cursor: pointer;
+      padding: @space-3;
     }
 
-    .undo {
-      margin-right: @space-3;
-    }
-
-    .close {
-      margin-left: @space-3;
+    svg {
+      display: flex;
     }
   }
 }
@@ -77,11 +75,12 @@
   box-sizing: border-box;
   box-shadow: @shadow-3;
   display: flex;
+  align-items: center;
   font: inherit;
   height: 44px;
   justify-content: space-between;
   line-height: 16px;
   max-width: 100%;
   min-width: 565px;
-  padding: 14px 15px;
+  padding: 0 3px 0 15px;
 }

--- a/packages/components-web/src/components/core-toast/core-toast.tsx
+++ b/packages/components-web/src/components/core-toast/core-toast.tsx
@@ -31,7 +31,19 @@ export class Toast implements ComponentInterface {
           <div class="toast-triggers">
             <div class="undo">Undo</div>
             <div class="close">
-              <core-icon icon="cross"></core-icon>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="currentColor"
+                class="cross"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M9.41 8l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 0 0-1.71-.71L8 6.59l-3.29-3.3a1.003 1.003 0 0 0-1.42 1.42L6.59 8 3.3 11.29c-.19.18-.3.43-.3.71a1.003 1.003 0 0 0 1.71.71L8 9.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 0 0 .71-1.71L9.41 8z"
+                />
+              </svg>
             </div>
           </div>
         </div>

--- a/packages/components-web/src/components/core-toggle/core-toggle.less
+++ b/packages/components-web/src/components/core-toggle/core-toggle.less
@@ -45,7 +45,7 @@
 
   // @Prop labelPositionProps
   &([label-position="right"]) {
-    .label-outer {
+    label {
       margin-left: @space-2;
     }
 
@@ -55,7 +55,7 @@
   }
 
   &([label-position="left"]) {
-    .label-outer {
+    label {
       margin-right: @space-2;
     }
   }

--- a/packages/components-web/src/components/core-toggle/core-toggle.tsx
+++ b/packages/components-web/src/components/core-toggle/core-toggle.tsx
@@ -50,7 +50,7 @@ export class Toggle implements ComponentInterface {
   /**
    * If applied, the user must fill in a value before submitting a form containing this element.
    */
-  @Prop({ reflect: true }) required = false;
+  @Prop() required = false;
 
   /**
    * Apply the pre-defined large element size styling.
@@ -75,11 +75,7 @@ export class Toggle implements ComponentInterface {
         onClick={this.handleClick}
       >
         <div class="toggle-outer">
-          {this.label && (
-            <div class="label-outer">
-              <label htmlFor={this.label}>{this.label}</label>
-            </div>
-          )}
+          {this.label && <label htmlFor={this.label}>{this.label}</label>}
           <input
             id={this.label || ""}
             class="native-element"

--- a/packages/components-web/src/index.html
+++ b/packages/components-web/src/index.html
@@ -478,28 +478,47 @@
               <span class="hint">Large</span>
             </div>
             <div class="radio grid">
-              <core-radio label="Radio"></core-radio>
-              <core-radio label="Large Radio" size="large"></core-radio>
+              <core-radio name="radio-group" label="Radio"></core-radio>
+              <core-radio
+                name="radio-group"
+                label="Large Radio"
+                size="large"
+              ></core-radio>
             </div>
             <div class="radio grid">
-              <core-radio label="Selected radio" checked></core-radio>
               <core-radio
+                name="radio-group"
+                label="Selected radio"
+                checked
+              ></core-radio>
+              <core-radio
+                name="radio-group"
                 label="Large Selected radio"
                 size="large"
                 checked
               ></core-radio>
             </div>
             <div class="radio grid">
-              <core-radio label="Disabled Radio" disabled></core-radio>
               <core-radio
+                name="radio-group"
+                label="Disabled Radio"
+                disabled
+              ></core-radio>
+              <core-radio
+                name="radio-group"
                 label="Disabled Large Radio"
                 size="large"
                 disabled
               ></core-radio>
             </div>
             <div class="radio grid">
-              <core-radio label="Left Label" label-position="left"></core-radio>
               <core-radio
+                name="radio-group"
+                label="Left Label"
+                label-position="left"
+              ></core-radio>
+              <core-radio
+                name="radio-group"
                 label="Left Large Label"
                 label-position="left"
                 size="large"
@@ -1025,14 +1044,14 @@
             </div>
             <div class="tabs">
               <core-tab-group>
-                <core-tab class="active">Active</core-tab>
+                <core-tab active>Active</core-tab>
                 <core-tab>Default</core-tab>
-                <core-tab class="disabled">Disabled</core-tab>
+                <core-tab disabled>Disabled</core-tab>
               </core-tab-group>
             </div>
             <div class="tabs">
               <core-tab-group>
-                <core-tab class="active">Active</core-tab>
+                <core-tab active>Active</core-tab>
                 <core-tab>Default</core-tab>
                 <core-tab>
                   With Badge
@@ -1040,7 +1059,7 @@
                     >3</core-badge
                   >
                 </core-tab>
-                <core-tab class="disabled">Disabled</core-tab>
+                <core-tab disabled>Disabled</core-tab>
               </core-tab-group>
             </div>
           </div>
@@ -1050,9 +1069,9 @@
             </div>
             <div class="tabs">
               <core-tab-group size="small">
-                <core-tab class="active">Active</core-tab>
+                <core-tab active>Active</core-tab>
                 <core-tab>Default</core-tab>
-                <core-tab class="disabled">Disabled</core-tab>
+                <core-tab disabled>Disabled</core-tab>
               </core-tab-group>
             </div>
           </div>


### PR DESCRIPTION
## Summary of Changes:

- Inline `Informer` SVGs from from https://github.com/iFixit/core-design/issues/68
- adds `pill` less mixin
- remove label containers
- misc low-level refactoring

#### CR:

When reviewing larger pulls, search for `components-web/src/components/` in the `Files changed` github tab to exclude compiled boilerplate.

qa_req 0