### PR TITLE
core-components: storybook/core-dropdown improvements

### DIFF
--- a/packages/components-web/.storybook/preview-head.html
+++ b/packages/components-web/.storybook/preview-head.html
@@ -11,16 +11,25 @@
     src: local("Inter"),
       url("./assets/font/Inter-subset.var.woff2?v3.13") format("woff2");
   }
+
+  #root-inner {
+    display: flex;
+    min-height: 90vh;
+  }
+  #root-inner > * {
+    margin: auto;
+  }
+
+  .simplebar-content label > span {
+    min-width: 135px !important;
+  }
+
   .story {
     display: grid;
     grid-gap: 32px;
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
   }
-  .center {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+
   .flex {
     display: flex;
     align-items: center;

--- a/packages/components-web/src/components/core-dropdown/core-dropdown.less
+++ b/packages/components-web/src/components/core-dropdown/core-dropdown.less
@@ -6,18 +6,9 @@
   white-space: nowrap;
   width: inherit;
 
-  // @Prop wrap
-  &([wrap]:not([wrap="false"])) {
-    white-space: unset;
-  }
-
   // @Prop alignment
   &([alignment="left"]) {
-    .menu-outer {
-      left: calc(~"50% -" @space-3);
-      transform: translateX(-@space-2);
-    }
-
+    .menu-outer,
     .arrow {
       left: 0;
     }
@@ -35,11 +26,7 @@
   }
 
   &([alignment="right"]) {
-    .menu-outer {
-      right: calc(~"50% -" @space-3);
-      transform: translateX(@space-2);
-    }
-
+    .menu-outer,
     .arrow {
       right: 0;
     }
@@ -48,7 +35,7 @@
   // @Prop direction
   &([direction="up"]) {
     .menu-outer {
-      bottom: 100%;
+      bottom: calc(~"100% +" @space-1);
     }
 
     .menu {
@@ -73,7 +60,7 @@
 
   &([direction]:not([direction="up"])) {
     .menu-outer {
-      top: 100%;
+      top: calc(~"100% +" @space-1);
     }
 
     .menu {
@@ -93,6 +80,26 @@
         top: -10px;
       }
     }
+  }
+
+  // @Prop onCenter
+  &([trigger-centered]:not([trigger-centered="false"])[alignment="left"]) {
+    .menu-outer {
+      left: calc(~"50% -" @space-3);
+      transform: translateX(-@space-2);
+    }
+  }
+
+  &([trigger-centered]:not([trigger-centered="false"])[alignment="right"]) {
+    .menu-outer {
+      right: calc(~"50% -" @space-3);
+      transform: translateX(@space-2);
+    }
+  }
+
+  // @Prop wrap
+  &([wrap]:not([wrap="false"])) {
+    white-space: unset;
   }
 
   // Applied only when a core-dropdown is in a core-button slot
@@ -168,6 +175,7 @@
   }
 
   .trigger {
+    color: @color-gray-8;
     cursor: pointer;
     display: flex;
     align-items: center;

--- a/packages/components-web/src/components/core-dropdown/core-dropdown.stories.tsx
+++ b/packages/components-web/src/components/core-dropdown/core-dropdown.stories.tsx
@@ -25,7 +25,8 @@ export const PropStates = (): TemplateResult => {
         alignment=${select("Alignment", alignments, "left")}
         direction=${select("Direction", directions, "down")}
         hoverable=${boolean("Hoverable", false)}
-        wrap=${boolean("wrap", false)}
+        trigger-centered=${boolean("Trigger Centered", false)}
+        wrap=${boolean("Wrap", false)}
       >
         <div slot="trigger">
           <core-icon slot="icon" icon="more" color="gray-5"></core-icon>
@@ -65,7 +66,7 @@ export const Default = (): TemplateResult => {
     <div class="center">
       <core-dropdown>
         <div slot="trigger">
-          <core-icon slot="icon" icon="more" color="gray-5"></core-icon>
+          Trigger can be anything
         </div>
         <core-dropdown-item href="#">
           <core-icon
@@ -91,6 +92,21 @@ export const Default = (): TemplateResult => {
         </core-dropdown-item>
         <core-dropdown-item>
           Nested content can be anything
+        </core-dropdown-item>
+      </core-dropdown>
+    </div>
+  `;
+};
+
+export const TriggerCentered = (): TemplateResult => {
+  return html`
+    <div class="center">
+      <core-dropdown trigger-centered>
+        <div slot="trigger">
+          <core-icon slot="icon" icon="more" color="gray-5"></core-icon>
+        </div>
+        <core-dropdown-item href="#">
+          ^^ use prop "trigger-centered" for those itty-bitty triggers
         </core-dropdown-item>
       </core-dropdown>
     </div>
@@ -125,6 +141,43 @@ export const Up = (): TemplateResult => {
             style="margin-right:8px"
           ></core-icon>
           Option 3
+        </core-dropdown-item>
+      </core-dropdown>
+    </div>
+  `;
+};
+
+export const Wrap = (): TemplateResult => {
+  return html`
+    <div class="center">
+      <core-dropdown wrap>
+        <div slot="trigger">
+          <core-icon slot="icon" icon="more" color="gray-5"></core-icon>
+        </div>
+        <core-dropdown-item href="#">
+          <core-icon
+            slot="icon"
+            icon="cart"
+            color="green"
+            style="margin-right:8px"
+          ></core-icon>
+          Option 1
+        </core-dropdown-item>
+        <core-dropdown-item href="#">
+          <core-icon slot="icon" icon="gear" color="red"></core-icon>
+          <span style="margin-left:8px">Option 2</span>
+        </core-dropdown-item>
+        <core-dropdown-item href="#">
+          <core-icon
+            slot="icon"
+            icon="archive"
+            color="blue"
+            style="margin-right:8px"
+          ></core-icon>
+          Option 3
+        </core-dropdown-item>
+        <core-dropdown-item>
+          Nested content can be anything
         </core-dropdown-item>
       </core-dropdown>
     </div>

--- a/packages/components-web/src/components/core-dropdown/core-dropdown.tsx
+++ b/packages/components-web/src/components/core-dropdown/core-dropdown.tsx
@@ -27,6 +27,11 @@ export class Dropdown implements ComponentInterface {
   @Prop({ reflect: true }) hoverable = false;
 
   /**
+   * Center the dropdown arrow on the trigger element, overwriting the `alignment` prop inheritance.
+   */
+  @Prop() triggerCentered = false;
+
+  /**
    * The dropdown will wrap if applied.
    */
   @Prop() wrap = false;

--- a/packages/components-web/src/components/core-dropdown/readme.md
+++ b/packages/components-web/src/components/core-dropdown/readme.md
@@ -5,13 +5,14 @@
 
 ## Properties
 
-| Property    | Attribute   | Description                                                  | Type                            | Default  |
-| ----------- | ----------- | ------------------------------------------------------------ | ------------------------------- | -------- |
-| `active`    | `active`    | The dropdown visibility                                      | `boolean`                       | `false`  |
-| `alignment` | `alignment` | The element alignment                                        | `"center" \| "left" \| "right"` | `"left"` |
-| `direction` | `direction` | The dropdown direction to expand.                            | `"down" \| "up"`                | `"down"` |
-| `hoverable` | `hoverable` | The dropdown will show up when hovering the dropdown-trigger | `boolean`                       | `false`  |
-| `wrap`      | `wrap`      | The dropdown will wrap if applied.                           | `boolean`                       | `false`  |
+| Property          | Attribute          | Description                                                                                     | Type                            | Default  |
+| ----------------- | ------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------- | -------- |
+| `active`          | `active`           | The dropdown visibility                                                                         | `boolean`                       | `false`  |
+| `alignment`       | `alignment`        | The element alignment                                                                           | `"center" \| "left" \| "right"` | `"left"` |
+| `direction`       | `direction`        | The dropdown direction to expand.                                                               | `"down" \| "up"`                | `"down"` |
+| `hoverable`       | `hoverable`        | The dropdown will show up when hovering the dropdown-trigger                                    | `boolean`                       | `false`  |
+| `triggerCentered` | `trigger-centered` | Center the dropdown arrow on the trigger element, overwriting the `alignment` prop inheritance. | `boolean`                       | `false`  |
+| `wrap`            | `wrap`             | The dropdown will wrap if applied.                                                              | `boolean`                       | `false`  |
 
 
 ----------------------------------------------

--- a/packages/components-web/src/components/core-input/core-input.less
+++ b/packages/components-web/src/components/core-input/core-input.less
@@ -104,12 +104,9 @@
 }
 
 label {
+  color: @color-gray-8;
   display: flex;
   margin-bottom: @space-2;
-}
-
-label {
-  color: @color-gray-8;
   transition: color 0.12s ease-in-out;
 }
 

--- a/packages/components-web/src/components/core-popover/core-popover.stories.tsx
+++ b/packages/components-web/src/components/core-popover/core-popover.stories.tsx
@@ -13,53 +13,44 @@ const variations = {
 
 export const PropStates = (): TemplateResult => {
   return html`
-    <div style="display:flex;height:200px;">
-      <core-popover
-        active=${boolean("Active", false)}
-        hoverable=${boolean("Hoverable", false)}
-        variation=${select("Variation", variations, "top")}
-        style="margin:auto auto 0;"
-      >
-        <core-button slot="trigger">Trigger</core-button>
-        <span slot="title">Popover Title</span>
-        <div>The quick brown fox jumps over the lazy dog.</div>
-      </core-popover>
-    </div>
+    <core-popover
+      active=${boolean("Active", false)}
+      hoverable=${boolean("Hoverable", false)}
+      variation=${select("Variation", variations, "top")}
+    >
+      <core-button slot="trigger">Trigger</core-button>
+      <span slot="title">Popover Title</span>
+      <div>The quick brown fox jumps over the lazy dog.</div>
+    </core-popover>
   `;
 };
 
 export const Default = (): TemplateResult => {
   return html`
-    <div style="display:flex;height:200px;">
-      <core-popover style="margin:auto auto 0;">
-        <core-button slot="trigger">Trigger</core-button>
-        <span slot="title">Popover Title</span>
-        <div>The quick brown fox jumps over the lazy dog.</div>
-      </core-popover>
-    </div>
+    <core-popover>
+      <core-button slot="trigger">Trigger</core-button>
+      <span slot="title">Popover Title</span>
+      <div>The quick brown fox jumps over the lazy dog.</div>
+    </core-popover>
   `;
 };
 
 export const Bottom = (): TemplateResult => {
   return html`
-    <div style="display:flex;height:200px;">
-      <core-popover variation="bottom" style="margin:50px auto auto;">
-        <core-button slot="trigger">Trigger</core-button>
-        <span slot="title">Popover Title</span>
-        <div>The quick brown fox jumps over the lazy dog.</div>
-      </core-popover>
-    </div>
+    <core-popover variation="bottom">
+      <core-button slot="trigger">Trigger</core-button>
+      <span slot="title">Popover Title</span>
+      <div>The quick brown fox jumps over the lazy dog.</div>
+    </core-popover>
   `;
 };
 
 export const Hoverable = (): TemplateResult => {
   return html`
-    <div style="display:flex;height:200px;">
-      <core-popover hoverable style="margin:auto auto 0;">
-        <core-button slot="trigger">Trigger</core-button>
-        <span slot="title">Popover Title</span>
-        <div>The quick brown fox jumps over the lazy dog.</div>
-      </core-popover>
-    </div>
+    <core-popover hoverable>
+      <core-button slot="trigger">Trigger</core-button>
+      <span slot="title">Popover Title</span>
+      <div>The quick brown fox jumps over the lazy dog.</div>
+    </core-popover>
   `;
 };

--- a/packages/components-web/src/components/core-progress/core-progress.less
+++ b/packages/components-web/src/components/core-progress/core-progress.less
@@ -1,7 +1,7 @@
 // `:host` targets the custom element compiled by Stencil
 :host {
   display: flex;
-  width: inherit;
+  width: 100%;
 
   // @Prop color
   &([color="black"]) progress::-webkit-progress-value {

--- a/packages/components-web/src/components/core-spinner/core-spinner.less
+++ b/packages/components-web/src/components/core-spinner/core-spinner.less
@@ -1,3 +1,5 @@
+@spinnerAnimation: spinnerAnimation 1s infinite linear;
+
 // `:host` targets the custom element compiled by Stencil
 :host {
   display: flex;
@@ -45,7 +47,7 @@
 
   // @Prop size
   &([size="small"]) .spinner {
-    animation: spinnerAnimation 1s infinite linear;
+    animation: @spinnerAnimation;
     height: 24px;
     width: 24px;
 
@@ -64,13 +66,13 @@
   }
 
   &([size="default"]) .spinner {
-    animation: spinnerAnimation 1.5s infinite linear;
+    animation: @spinnerAnimation;
     height: 40px;
     width: 40px;
   }
 
   &([size="large"]) .spinner {
-    animation: spinnerAnimation 2s infinite linear;
+    animation: @spinnerAnimation;
     height: 80px;
     width: 80px;
 


### PR DESCRIPTION
## Summary of Changes:

- center stories by default/remove obsolete centering divs
- add more default space between dropdown and trigger
- add `trigger-centered` prop/styling
- add `core-progress` width inheritance
- set default `core-spinner` animation variable

#### CR:

qa_req 0
