### PR TITLE
Core Dropdown: Close when clicking outside dropdown

### DIFF
--- a/packages/components-web/src/components/core-dropdown/core-dropdown.tsx
+++ b/packages/components-web/src/components/core-dropdown/core-dropdown.tsx
@@ -42,8 +42,20 @@ export class Dropdown implements ComponentInterface {
   private handleClick = (): void => {
     if (!this.hoverable) {
       this.active = !this.active;
+
+      if (this.active) {
+        window.addEventListener('click', this.handleOutsideClick);
+      } else {
+        window.removeEventListener('click', this.handleOutsideClick);
+      }
     }
   };
+
+  private handleOutsideClick = (event: Event): void => {
+    if (!(event.target as HTMLElement).closest("core-dropdown")) {
+      this.active = false;
+    }
+  }
 
   render(): JSX.Element {
     return (


### PR DESCRIPTION
This updates the core dropdown so that it closes whenever you click outside of it.

QA
===
- Run the code in the packages/components-web with npm run storybook
- Click on the core-dropdown and see it open and that clicking outside of it closes it
- Click on elements in the dropdown and verify it doesn't close 


Closes iFixit/core-design#61