### PR TITLE
core-components: bold to semi-bold primitive, stop disabled pointer-events

### DIFF
--- a/packages/components-web/src/components/core-badge/core-badge.less
+++ b/packages/components-web/src/components/core-badge/core-badge.less
@@ -77,7 +77,7 @@
   display: flex;
   font: inherit;
   font-size: 12px;
-  font-weight: bold;
+  font-weight: @font-weight-semi-bold;
   justify-content: center;
   line-height: 15px;
   max-width: 100%;

--- a/packages/components-web/src/components/core-button/core-button.less
+++ b/packages/components-web/src/components/core-button/core-button.less
@@ -6,6 +6,19 @@
   max-width: 100%;
   vertical-align: middle;
 
+  // @Prop disabled
+  &([disabled]:not([disabled="false"])),
+  &([disabled="true"]) {
+    cursor: not-allowed;
+
+    .native-element {
+      background-color: @color-gray-1;
+      box-shadow: @focus-box-shadow-transparent;
+      color: @color-gray-4;
+      pointer-events: none;
+    }
+  }
+
   // @Prop basic variation
   &([variation="basic"]) {
     .native-element {
@@ -69,6 +82,7 @@
 
       &[disabled] {
         background-color: fade(@color-blue, 50%);
+        color: @color-white;
       }
     }
   }
@@ -134,6 +148,7 @@
 
       &[disabled] {
         background-color: fade(@color-green, 50%);
+        color: @color-white;
       }
     }
   }
@@ -546,7 +561,7 @@
   // @Prop small size
   ([size="small"]) {
     .native-element {
-      font-weight: normal;
+      font-weight: @font-weight-normal;
       padding-right: @space-3;
       padding-left: @space-3;
     }
@@ -622,7 +637,7 @@
   box-sizing: border-box;
   display: flex;
   font: inherit;
-  font-weight: bold;
+  font-weight: @font-weight-semi-bold;
   line-height: 18px;
   outline: none;
   padding: 0 15px;
@@ -634,13 +649,6 @@
   &:not([disabled]):not([loading]):hover,
   &:not([disabled]):not([loading]):active {
     cursor: pointer;
-  }
-
-  &[disabled] {
-    background-color: @color-gray-1;
-    box-shadow: @focus-box-shadow-transparent;
-    color: @color-gray-4;
-    cursor: not-allowed;
   }
 
   .text-wrap {

--- a/packages/components-web/src/components/core-checkbox/core-checkbox.less
+++ b/packages/components-web/src/components/core-checkbox/core-checkbox.less
@@ -7,6 +7,8 @@
   // @Prop disabled
   &([disabled]:not([disabled="false"])),
   &([disabled="true"]) {
+    cursor: not-allowed;
+
     label {
       color: @color-gray-4;
     }
@@ -15,7 +17,7 @@
       background-color: @color-gray-1;
       box-shadow: 0 0 0 0 transparent inset;
       color: inherit;
-      cursor: not-allowed;
+      pointer-events: none;
     }
   }
 

--- a/packages/components-web/src/components/core-dropdown/core-dropdown.less
+++ b/packages/components-web/src/components/core-dropdown/core-dropdown.less
@@ -196,7 +196,7 @@
     box-shadow: @shadow-3;
     box-sizing: border-box;
     flex-direction: column;
-    font-weight: normal;
+    font-weight: @font-weight-normal;
     margin-top: @space-4;
     padding-top: @space-2;
     padding-bottom: @space-1;

--- a/packages/components-web/src/components/core-input/core-input.less
+++ b/packages/components-web/src/components/core-input/core-input.less
@@ -14,9 +14,18 @@
   // @Prop disabled
   &([disabled]:not([disabled="false"])),
   &([disabled="true"]) {
+    cursor: not-allowed;
+
     core-icon,
     label {
       color: @color-gray-4 !important;
+    }
+
+    .native-element {
+      background-color: @color-gray-1;
+      border-color: transparent;
+      color: @color-gray-4;
+      pointer-events: none;
     }
   }
 
@@ -145,12 +154,5 @@ label {
       border-color: @color-gray-5;
       box-shadow: @focus-box-shadow;
     }
-  }
-
-  &:disabled {
-    background-color: @color-gray-1;
-    border-color: transparent;
-    color: @color-gray-4;
-    cursor: not-allowed;
   }
 }

--- a/packages/components-web/src/components/core-popover/core-popover.less
+++ b/packages/components-web/src/components/core-popover/core-popover.less
@@ -116,7 +116,7 @@
 .title {
   color: @color-gray-6;
   font-size: 17px;
-  font-weight: bold;
+  font-weight: @font-weight-semi-bold;
   line-height: 20px;
   margin-bottom: @space-2;
 }

--- a/packages/components-web/src/components/core-radio/core-radio.less
+++ b/packages/components-web/src/components/core-radio/core-radio.less
@@ -8,6 +8,8 @@
   // @Prop disabled
   &([disabled]:not([disabled="false"])),
   &([disabled="true"]) {
+    cursor: not-allowed;
+
     label {
       color: @color-gray-4;
     }
@@ -17,7 +19,7 @@
       border-color: transparent;
       box-shadow: 0 0 0 0 transparent inset;
       color: inherit;
-      cursor: not-allowed;
+      pointer-events: none;
     }
   }
 

--- a/packages/components-web/src/components/core-tab-group/core-tab-group.less
+++ b/packages/components-web/src/components/core-tab-group/core-tab-group.less
@@ -34,7 +34,7 @@
   .native-element {
     align-items: stretch;
     display: flex;
-    font-weight: bold;
+    font-weight: @font-weight-semi-bold;
     height: 35px;
     justify-content: flex-start;
     list-style: none;

--- a/packages/components-web/src/components/core-tab/core-tab.less
+++ b/packages/components-web/src/components/core-tab/core-tab.less
@@ -43,16 +43,20 @@ core-tab {
     }
   }
 
-  &[disabled] .native-element {
-    color: @color-gray-3;
+  &[disabled] {
+    cursor: not-allowed;
 
-    &::after {
-      content: none;
-    }
-
-    &:hover {
+    .native-element {
       color: @color-gray-3;
-      cursor: not-allowed;
+      pointer-events: none;
+
+      &::after {
+        content: none;
+      }
+
+      &:hover {
+        color: @color-gray-3;
+      }
     }
   }
 

--- a/packages/components-web/src/components/core-tag/core-tag.less
+++ b/packages/components-web/src/components/core-tag/core-tag.less
@@ -93,7 +93,6 @@
   // @Prop small size
   &([size="small"]) .native-element {
     font-size: 12px;
-    font-weight: 500;
     height: 18px;
     line-height: 14px;
     padding: 2px @space-1;
@@ -112,7 +111,7 @@
   cursor: default;
   display: flex;
   font: inherit;
-  font-weight: 600;
+  font-weight: @font-weight-semi-bold;
   height: 24px;
   letter-spacing: 0.02em;
   line-height: 16px;

--- a/packages/components-web/src/components/core-textarea/core-textarea.less
+++ b/packages/components-web/src/components/core-textarea/core-textarea.less
@@ -6,9 +6,15 @@
   // @Prop disabled
   &([disabled]:not([disabled="false"])),
   &([disabled="true"]) {
+    cursor: not-allowed;
+
     core-icon,
     label {
       color: @color-gray-4 !important;
+    }
+
+    .native-element {
+      pointer-events: none;
     }
   }
 

--- a/packages/components-web/src/components/core-toggle/core-toggle.less
+++ b/packages/components-web/src/components/core-toggle/core-toggle.less
@@ -9,6 +9,8 @@
   // @Prop disabled
   &([disabled]:not([disabled="false"])),
   &([disabled="true"]) {
+    cursor: not-allowed;
+
     label {
       color: @color-gray-4;
     }
@@ -17,7 +19,7 @@
       background-color: @color-gray-1;
       box-shadow: 0 0 0 0 transparent inset;
       color: inherit;
-      cursor: not-allowed;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
## Summary of Changes:

- Swap bold to semi-bold primitive because Inter renders heavier than most other fonts
- Stop disabled component pointer-events at the native element level

#### CR:

cr_req 1

#### QA:

qa_req 0
