### PR TITLE
Fix tab regression

### DIFF
--- a/packages/components-web/src/components/core-tab-group/core-tab-group.less
+++ b/packages/components-web/src/components/core-tab-group/core-tab-group.less
@@ -7,6 +7,7 @@
     content: "";
     background-color: @color-gray-2;
     border-radius: @border-radius-pill;
+    height: 3px;
     position: absolute;
     bottom: 0;
     width: 100%;
@@ -21,7 +22,7 @@
     line-height: 1.142857;
 
     &::after {
-      border-radius: @border-radius-pill;
+      height: 2px;
     }
 
     .native-element {

--- a/packages/components-web/src/components/core-tab/core-tab.less
+++ b/packages/components-web/src/components/core-tab/core-tab.less
@@ -14,6 +14,7 @@ core-tab {
       content: "";
       background-color: transparent;
       border-radius: @border-radius-pill;
+      height: 3px;
       position: absolute;
       left: 0;
       bottom: 0;


### PR DESCRIPTION
## Summary of Changes:

- Missed this `core-tab` regression from https://github.com/iFixit/core-design/pull/108
  - Regression caused by eliminating a mixin that passed a pixel value for the `height` and the height divided by 2 for the `border-radius` value
- Fixed the regression

#### QA:

qa_req 0
