### PR TITLE
Load Inter Externally

### DIFF
--- a/packages/components-web/src/assets/style/global.less
+++ b/packages/components-web/src/assets/style/global.less
@@ -5,11 +5,11 @@
   font-display: swap;
   font-style: oblique 0deg 10deg;
   src: local("Inter"),
-    url("../font/Inter-subset.var.woff2?v3.13") format("woff2");
+    url("https://s3.amazonaws.com/ifixit-assets/static/fonts/inter/Inter-subset.var.woff2?v3.13") format("woff2");
 }
 
 // 2. Imports
-@import (reference) "https://unpkg.com/@core-ds/primitives/core-primitives.less";
+@import "https://unpkg.com/@core-ds/primitives/core-primitives.less";
 
 // 3. Variables
 @focus-box-shadow: 0 0 0 3px fade(@color-blue-light-1, 30%);
@@ -24,12 +24,10 @@
 }
 
 .inter-font {
-  font-family: "Inter Var", -apple-system, BlinkMacSystemFont, Segoe UI,
-    Helvetica, Arial, sans-serif;
-  font-feature-settings: "calt" on, "cpsp" on, "cv01" on, "cv03" on, "cv04" on,
-    "cv05" on, "cv10" on, "kern" on, "liga" on;
-  font-size: 14px;
-  line-height: 1.142857;
+  font-family: @font-family-inter;
+  font-feature-settings: @font-settings-inter;
+  font-size: @font-size-1;
+  line-height: @line-height-base;
   text-rendering: auto;
 
   i {


### PR DESCRIPTION
## Summary of Changes:

- Use external s3 inter font URL
- Remove obsolete LESS `(reference)`
- Use new primitives for font settings from [v1.2](https://unpkg.com/@core-ds/primitives@1.2.0/core-primitives.less)

#### QA:
qa_req 0

cc @tgines - this _should_ fix the loading of the font file when components are used externally and Inter is not present. `global.less` is loaded into every component [here](https://github.com/iFixit/core-design/blob/master/packages/components-web/stencil.config.ts#L38).