### PR TITLE
Fix size="small" badge regression

### DIFF
--- a/packages/components-web/src/components/core-badge/core-badge.less
+++ b/packages/components-web/src/components/core-badge/core-badge.less
@@ -49,6 +49,7 @@
   &([size="small"]) .native-element {
     border-radius: @border-radius-pill;
     font-size: 11px;
+    height: 16px;
     letter-spacing: unset;
     line-height: @space-3;
     min-width: @space-4;


### PR DESCRIPTION
## Background:
Unsure of origin, but the core-badge has taken on the large badge height. Let's fix that.

## Summary of Changes:
- Force small badge height to retain circular design

## CR:
Preview: https://deploy-preview-111--core-ds-components.netlify.app/#badge-section

## QA:
qa_req 0
