### PR TITLE
Fix core-avatar square safari bug

### DIFF
--- a/packages/components-web/src/components/core-avatar/core-avatar.less
+++ b/packages/components-web/src/components/core-avatar/core-avatar.less
@@ -10,6 +10,12 @@
     max-width: 64px;
   }
 
+  &([variation="circle"]) {
+    ::slotted(img) {
+      border-radius: @border-radius-pill;
+    }
+  }
+
   &([variation="square"]) {
     ::slotted(img) {
       border-radius: @border-radius-md;
@@ -36,7 +42,6 @@
 }
 
 ::slotted(img) {
-  border-radius: @border-radius-pill;
   object-fit: cover;
   overflow: hidden;
 }


### PR DESCRIPTION
## Background:

There's a Safari bug that applies the `circle` border radius to the `square` variant of the core-avatar. For whatever reason, even though it has lower specificity, the later defined `circle` radius is applied.

## Summary of Changes:

- [x] Separate the `circle` and the `square` variant styles so they cannot conflict.

#### QA:

qa_req 0
