### PR TITLE
Dependencies: Fix `tar` dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4815,9 +4815,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/tar": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.16.tgz",
-      "integrity": "sha512-gOVUT/KWPkGFZQmCRDVFNUWBl7niIo/PRR7lzrIqtZpit+st54lGROuVjc6zEQM9FhH+dJfQIl+9F0k8GNXg5g==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "dev": true,
       "dependencies": {
         "chownr": "^1.1.4",
@@ -6582,9 +6582,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.7.tgz",
-      "integrity": "sha512-PBoRkOJU0X3lejJ8GaRCsobjXTgFofRDSPdSUhRSdlwJfifRlQBwGXitDItdGFu0/h0XDMCkig0RN1iT7DBxhA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -11141,9 +11141,9 @@
           "dev": true
         },
         "tar": {
-          "version": "4.4.16",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.16.tgz",
-          "integrity": "sha512-gOVUT/KWPkGFZQmCRDVFNUWBl7niIo/PRR7lzrIqtZpit+st54lGROuVjc6zEQM9FhH+dJfQIl+9F0k8GNXg5g==",
+          "version": "4.4.19",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
           "dev": true,
           "requires": {
             "chownr": "^1.1.4",
@@ -12478,9 +12478,9 @@
       }
     },
     "tar": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.7.tgz",
-      "integrity": "sha512-PBoRkOJU0X3lejJ8GaRCsobjXTgFofRDSPdSUhRSdlwJfifRlQBwGXitDItdGFu0/h0XDMCkig0RN1iT7DBxhA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",


### PR DESCRIPTION
## Summary of Changes:

- Fix this dependabot issue by running `npm audit fix`: https://github.com/iFixit/core-design/security/dependabot/package-lock.json/tar/open

qa_req 0
